### PR TITLE
Combat instance

### DIFF
--- a/src/main/java/com/dis/bot/commands/age/init/AgeHiddenInitiativeRollsCommand.java
+++ b/src/main/java/com/dis/bot/commands/age/init/AgeHiddenInitiativeRollsCommand.java
@@ -1,12 +1,14 @@
 package com.dis.bot.commands.age.init;
 
 import com.dis.bot.commands.SlashCommand;
+import com.dis.bot.service.CombatService;
 import com.dis.bot.service.age.AgeCharacterService;
 import com.dis.bot.service.age.AgeInitiativeService;
 import discord4j.core.event.domain.interaction.ChatInputInteractionEvent;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
+import static com.dis.bot.tool.ChannelGetter.getChannel;
 import static com.dis.bot.tool.D20Roll.rollD20WithBonus;
 import static com.dis.bot.tool.EventOptionNameGetter.getEventOption;
 
@@ -15,10 +17,15 @@ public class AgeHiddenInitiativeRollsCommand implements SlashCommand {
 
     private final AgeInitiativeService service;
     private final AgeCharacterService characterService;
+    private final CombatService combatService;
 
-    public AgeHiddenInitiativeRollsCommand(AgeInitiativeService service, AgeCharacterService characterService){
+    public AgeHiddenInitiativeRollsCommand(AgeInitiativeService service,
+                                           AgeCharacterService characterService,
+                                           CombatService combatService){
         this.service = service;
         this.characterService = characterService;
+        this.combatService = combatService;
+
     }
 
     @Override
@@ -59,8 +66,10 @@ public class AgeHiddenInitiativeRollsCommand implements SlashCommand {
                 Long.parseLong(mdsArray[i]));
         }
 
+        var combat = combatService.newCombat(namesArray, getChannel(event));
+
         return  event.reply()
             .withEphemeral(true)
-            .withContent(service.showInitiativeTable());
+            .withContent(service.showInitiativeTable(combat));
     }
 }

--- a/src/main/java/com/dis/bot/commands/age/init/AgeShowInitCommand.java
+++ b/src/main/java/com/dis/bot/commands/age/init/AgeShowInitCommand.java
@@ -1,18 +1,23 @@
 package com.dis.bot.commands.age.init;
 
 import com.dis.bot.commands.SlashCommand;
+import com.dis.bot.service.CombatService;
 import com.dis.bot.service.age.AgeInitiativeService;
 import discord4j.core.event.domain.interaction.ChatInputInteractionEvent;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
+import static com.dis.bot.tool.ChannelGetter.getChannel;
+
 @Component
 public class AgeShowInitCommand implements SlashCommand {
 
     private final AgeInitiativeService service;
+    private final CombatService combatService;
 
-    public AgeShowInitCommand(AgeInitiativeService service){
+    public AgeShowInitCommand(AgeInitiativeService service, CombatService combatService){
         this.service = service;
+        this.combatService = combatService;
     }
 
     @Override
@@ -22,8 +27,9 @@ public class AgeShowInitCommand implements SlashCommand {
 
     @Override
     public Mono<Void> handle(ChatInputInteractionEvent event) {
+        var combat = combatService.getCurrentChannelActiveCombat(getChannel(event));
         return  event.reply()
             .withEphemeral(false)
-            .withContent(service.showInitiativeTable());
+            .withContent(service.showInitiativeTable(combat));
     }
 }

--- a/src/main/java/com/dis/bot/commands/combat/CombatNextRoundCommand.java
+++ b/src/main/java/com/dis/bot/commands/combat/CombatNextRoundCommand.java
@@ -1,0 +1,35 @@
+package com.dis.bot.commands.combat;
+
+import com.dis.bot.commands.SlashCommand;
+import com.dis.bot.service.CombatService;
+import discord4j.core.event.domain.interaction.ChatInputInteractionEvent;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import static com.dis.bot.tool.EventOptionNameGetter.getEventOption;
+
+@Component
+public class CombatNextRoundCommand implements SlashCommand {
+
+    private final CombatService service;
+
+    public CombatNextRoundCommand(CombatService service){
+        this.service = service;
+    }
+
+    @Override
+    public String getName() {
+        return "combat-next-round";
+    }
+
+    @Override
+    public Mono<Void> handle(ChatInputInteractionEvent event) {
+        String id = getEventOption(event, "id");
+
+        var combat = service.nextRound(id);
+
+        return  event.reply()
+            .withEphemeral(false)
+            .withContent(String.format("Combat, round is %d", combat.getRound()));
+    }
+}

--- a/src/main/java/com/dis/bot/commands/combat/EndCombatCommand.java
+++ b/src/main/java/com/dis/bot/commands/combat/EndCombatCommand.java
@@ -1,0 +1,35 @@
+package com.dis.bot.commands.combat;
+
+import com.dis.bot.commands.SlashCommand;
+import com.dis.bot.service.CombatService;
+import discord4j.core.event.domain.interaction.ChatInputInteractionEvent;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import static com.dis.bot.tool.EventOptionNameGetter.getEventOption;
+
+@Component
+public class EndCombatCommand implements SlashCommand {
+
+    private final CombatService service;
+
+    public EndCombatCommand(CombatService service){
+        this.service = service;
+    }
+
+    @Override
+    public String getName() {
+        return "end-combat";
+    }
+
+    @Override
+    public Mono<Void> handle(ChatInputInteractionEvent event) {
+        String id = getEventOption(event, "id");
+
+        var combat = service.endCombat(id);
+
+        return  event.reply()
+            .withEphemeral(false)
+            .withContent(String.format("Combat, %s was ended", combat.getId()));
+    }
+}

--- a/src/main/java/com/dis/bot/commands/combat/EndCommand.java
+++ b/src/main/java/com/dis/bot/commands/combat/EndCommand.java
@@ -1,0 +1,34 @@
+package com.dis.bot.commands.combat;
+
+import com.dis.bot.commands.SlashCommand;
+import com.dis.bot.service.CombatService;
+import discord4j.core.event.domain.interaction.ChatInputInteractionEvent;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import static com.dis.bot.tool.ChannelGetter.getChannel;
+
+@Component
+public class EndCommand implements SlashCommand {
+
+    private final CombatService service;
+
+    public EndCommand(CombatService service){
+        this.service = service;
+    }
+
+    @Override
+    public String getName() {
+        return "end";
+    }
+
+    @Override
+    public Mono<Void> handle(ChatInputInteractionEvent event) {
+        var combat = service.nextRoundForChannel(getChannel(event));
+        service.endCombat(combat);
+
+        return  event.reply()
+            .withEphemeral(false)
+            .withContent(String.format("Combat, %s was ended", combat.getId()));
+    }
+}

--- a/src/main/java/com/dis/bot/commands/combat/NextRoundCommand.java
+++ b/src/main/java/com/dis/bot/commands/combat/NextRoundCommand.java
@@ -1,0 +1,33 @@
+package com.dis.bot.commands.combat;
+
+import com.dis.bot.commands.SlashCommand;
+import com.dis.bot.service.CombatService;
+import discord4j.core.event.domain.interaction.ChatInputInteractionEvent;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import static com.dis.bot.tool.ChannelGetter.getChannel;
+
+@Component
+public class NextRoundCommand implements SlashCommand {
+
+    private final CombatService service;
+
+    public NextRoundCommand(CombatService service){
+        this.service = service;
+    }
+
+    @Override
+    public String getName() {
+        return "next-round";
+    }
+
+    @Override
+    public Mono<Void> handle(ChatInputInteractionEvent event) {
+        var combat = service.nextRoundForChannel(getChannel(event));
+
+        return  event.reply()
+            .withEphemeral(false)
+            .withContent(String.format("Combat, round is %d", combat.getRound()));
+    }
+}

--- a/src/main/java/com/dis/bot/commands/combat/StartCombatCommand.java
+++ b/src/main/java/com/dis/bot/commands/combat/StartCombatCommand.java
@@ -1,0 +1,37 @@
+package com.dis.bot.commands.combat;
+
+import com.dis.bot.commands.SlashCommand;
+import com.dis.bot.service.CombatService;
+import discord4j.core.event.domain.interaction.ChatInputInteractionEvent;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import static com.dis.bot.tool.ChannelGetter.getChannel;
+import static com.dis.bot.tool.EventOptionNameGetter.getEventOption;
+
+@Component
+public class StartCombatCommand implements SlashCommand {
+
+    private final CombatService service;
+
+    public StartCombatCommand(CombatService service){
+        this.service = service;
+    }
+
+    @Override
+    public String getName() {
+        return "start-combat";
+    }
+
+    @Override
+    public Mono<Void> handle(ChatInputInteractionEvent event) {
+        String characterNames = getEventOption(event, "names");
+        var namesArray = characterNames.split(",");
+
+        var combat = service.newCombat(namesArray, getChannel(event));
+
+        return  event.reply()
+            .withEphemeral(false)
+            .withContent(String.format("Combat, %s was created", combat.getId()));
+    }
+}

--- a/src/main/java/com/dis/bot/commands/init/D20InitCommand.java
+++ b/src/main/java/com/dis/bot/commands/init/D20InitCommand.java
@@ -1,21 +1,25 @@
 package com.dis.bot.commands.init;
 
 import com.dis.bot.commands.SlashCommand;
+import com.dis.bot.service.CombatService;
 import com.dis.bot.service.InitiativeService;
 import com.dis.bot.tool.MemberNameGetter;
 import discord4j.core.event.domain.interaction.ChatInputInteractionEvent;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
+import static com.dis.bot.tool.ChannelGetter.getChannel;
 import static com.dis.bot.tool.MemberNameGetter.getUsername;
 
 @Component
 public class D20InitCommand implements SlashCommand {
 
     private final InitiativeService service;
+    private final CombatService combatService;
 
-    public D20InitCommand(InitiativeService service){
+    public D20InitCommand(InitiativeService service, CombatService combatService){
         this.service = service;
+        this.combatService = combatService;
     }
 
     @Override
@@ -26,7 +30,8 @@ public class D20InitCommand implements SlashCommand {
     @Override
     public Mono<Void> handle(ChatInputInteractionEvent event) {
         var memberName = getUsername(event);
-        var character = service.rollD20InitiativeFromMember(memberName);
+        var combat = combatService.getCurrentChannelActiveCombat(getChannel(event));
+        var character = service.rollD20InitiativeFromMember(memberName, combat);
 
         return  event.reply()
             .withEphemeral(false)

--- a/src/main/java/com/dis/bot/commands/init/HiddenInitiativeCommand.java
+++ b/src/main/java/com/dis/bot/commands/init/HiddenInitiativeCommand.java
@@ -1,13 +1,16 @@
 package com.dis.bot.commands.init;
 
 import com.dis.bot.commands.SlashCommand;
+import com.dis.bot.pojo.combat.Combat;
 import com.dis.bot.service.CharacterService;
+import com.dis.bot.service.CombatService;
 import com.dis.bot.service.InitiativeService;
 import discord4j.core.event.domain.interaction.ChatInputInteractionEvent;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
+import static com.dis.bot.tool.ChannelGetter.getChannel;
 import static com.dis.bot.tool.EventOptionNameGetter.getEventOption;
 
 @Component
@@ -16,10 +19,14 @@ public class HiddenInitiativeCommand implements SlashCommand {
 
     private final InitiativeService service;
     private final CharacterService characterService;
+    private final CombatService combatService;
 
-    public HiddenInitiativeCommand(InitiativeService service, CharacterService characterService){
+    public HiddenInitiativeCommand(InitiativeService service,
+                                   CharacterService characterService,
+                                   CombatService combatService){
         this.service = service;
         this.characterService = characterService;
+        this.combatService = combatService;
     }
 
     @Override
@@ -45,9 +52,11 @@ public class HiddenInitiativeCommand implements SlashCommand {
             characterService.create(namesArray[i], Long.parseLong(initiativesArray[i]));
         }
 
+        var combat = combatService.newCombat(namesArray, getChannel(event));
+
         return  event.reply()
             .withEphemeral(true)
-            .withContent(service.showInitiativeTable());
+            .withContent(service.showInitiativeTable(combat));
     }
 
 }

--- a/src/main/java/com/dis/bot/commands/init/HiddenInitiativeRollsCommand.java
+++ b/src/main/java/com/dis/bot/commands/init/HiddenInitiativeRollsCommand.java
@@ -2,11 +2,13 @@ package com.dis.bot.commands.init;
 
 import com.dis.bot.commands.SlashCommand;
 import com.dis.bot.service.CharacterService;
+import com.dis.bot.service.CombatService;
 import com.dis.bot.service.InitiativeService;
 import discord4j.core.event.domain.interaction.ChatInputInteractionEvent;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
+import static com.dis.bot.tool.ChannelGetter.getChannel;
 import static com.dis.bot.tool.D20Roll.rollD20WithBonus;
 import static com.dis.bot.tool.EventOptionNameGetter.getEventOption;
 
@@ -15,10 +17,14 @@ public class HiddenInitiativeRollsCommand implements SlashCommand {
 
     private final InitiativeService service;
     private final CharacterService characterService;
+    private final CombatService combatService;
 
-    public HiddenInitiativeRollsCommand(InitiativeService service, CharacterService characterService){
+    public HiddenInitiativeRollsCommand(InitiativeService service,
+                                        CharacterService characterService,
+                                        CombatService combatService){
         this.service = service;
         this.characterService = characterService;
+        this.combatService = combatService;
     }
 
     @Override
@@ -44,8 +50,10 @@ public class HiddenInitiativeRollsCommand implements SlashCommand {
             characterService.create(namesArray[i], rollD20WithBonus(Long.parseLong(initiativesArray[i])));
         }
 
+        var combat = combatService.newCombat(namesArray, getChannel(event));
+
         return  event.reply()
             .withEphemeral(true)
-            .withContent(service.showInitiativeTable());
+            .withContent(service.showInitiativeTable(combat));
     }
 }

--- a/src/main/java/com/dis/bot/commands/init/IniCommand.java
+++ b/src/main/java/com/dis/bot/commands/init/IniCommand.java
@@ -1,11 +1,13 @@
 package com.dis.bot.commands.init;
 
 import com.dis.bot.commands.SlashCommand;
+import com.dis.bot.service.CombatService;
 import com.dis.bot.service.InitiativeService;
 import discord4j.core.event.domain.interaction.ChatInputInteractionEvent;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
+import static com.dis.bot.tool.ChannelGetter.getChannel;
 import static com.dis.bot.tool.EventOptionNameGetter.getEventOptionAsLong;
 import static com.dis.bot.tool.MemberNameGetter.getUsername;
 
@@ -13,9 +15,11 @@ import static com.dis.bot.tool.MemberNameGetter.getUsername;
 public class IniCommand implements SlashCommand {
 
     private final InitiativeService service;
+    private final CombatService combatService;
 
-    public IniCommand(InitiativeService service){
+    public IniCommand(InitiativeService service, CombatService combatService){
         this.service = service;
+        this.combatService = combatService;
     }
 
     @Override
@@ -26,9 +30,9 @@ public class IniCommand implements SlashCommand {
     @Override
     public Mono<Void> handle(ChatInputInteractionEvent event) {
         Long bonus = getEventOptionAsLong(event, "initiative-bonus");
-
         var memberName = getUsername(event);
-        var character = service.rollD20InitiativeFromMemberWithBonus(memberName, bonus);
+        var combat = combatService.getCurrentChannelActiveCombat(getChannel(event));
+        var character = service.rollD20InitiativeFromMemberWithBonus(memberName, bonus, combat);
 
         return  event.reply()
             .withEphemeral(false)

--- a/src/main/java/com/dis/bot/commands/init/InitiativeCommand.java
+++ b/src/main/java/com/dis/bot/commands/init/InitiativeCommand.java
@@ -1,11 +1,14 @@
 package com.dis.bot.commands.init;
 
 import com.dis.bot.commands.SlashCommand;
+import com.dis.bot.pojo.combat.Combat;
+import com.dis.bot.service.CombatService;
 import com.dis.bot.service.InitiativeService;
 import discord4j.core.event.domain.interaction.ChatInputInteractionEvent;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
+import static com.dis.bot.tool.ChannelGetter.getChannel;
 import static com.dis.bot.tool.EventOptionNameGetter.getEventOption;
 import static com.dis.bot.tool.EventOptionNameGetter.getEventOptionAsLong;
 
@@ -13,9 +16,11 @@ import static com.dis.bot.tool.EventOptionNameGetter.getEventOptionAsLong;
 public class InitiativeCommand implements SlashCommand {
 
     private final InitiativeService service;
+    private final CombatService combatService;
 
-    public InitiativeCommand(InitiativeService service){
+    public InitiativeCommand(InitiativeService service, CombatService combatService){
         this.service = service;
+        this.combatService = combatService;
     }
 
     @Override
@@ -27,8 +32,8 @@ public class InitiativeCommand implements SlashCommand {
     public Mono<Void> handle(ChatInputInteractionEvent event) {
         Long initiative = getEventOptionAsLong(event, "initiative");
         String characterName = getEventOption(event, "name");
-
-        var character = service.setInitiative(characterName, initiative);
+        var combat = combatService.getCurrentChannelActiveCombat(getChannel(event));
+        var character = service.setInitiative(characterName, initiative, combat);
 
         return  event.reply()
             .withEphemeral(false)

--- a/src/main/java/com/dis/bot/commands/init/QuickInitCommand.java
+++ b/src/main/java/com/dis/bot/commands/init/QuickInitCommand.java
@@ -1,11 +1,13 @@
 package com.dis.bot.commands.init;
 
 import com.dis.bot.commands.SlashCommand;
+import com.dis.bot.service.CombatService;
 import com.dis.bot.service.InitiativeService;
 import discord4j.core.event.domain.interaction.ChatInputInteractionEvent;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
+import static com.dis.bot.tool.ChannelGetter.getChannel;
 import static com.dis.bot.tool.EventOptionNameGetter.getEventOptionAsLong;
 import static com.dis.bot.tool.MemberNameGetter.getUsername;
 
@@ -13,9 +15,11 @@ import static com.dis.bot.tool.MemberNameGetter.getUsername;
 public class QuickInitCommand implements SlashCommand {
 
     private final InitiativeService service;
+    private final CombatService combatService;
 
-    public QuickInitCommand(InitiativeService service){
+    public QuickInitCommand(InitiativeService service, CombatService combatService){
         this.service = service;
+        this.combatService = combatService;
     }
 
     @Override
@@ -26,9 +30,9 @@ public class QuickInitCommand implements SlashCommand {
     @Override
     public Mono<Void> handle(ChatInputInteractionEvent event) {
         Long initiative = getEventOptionAsLong(event, "initiative");
-
         var memberName = getUsername(event);
-        var character = service.setInitiativeFromMember(memberName, initiative);
+        var combat = combatService.getCurrentChannelActiveCombat(getChannel(event));
+        var character = service.setInitiativeFromMember(memberName, initiative, combat);
 
         return  event.reply()
             .withEphemeral(false)

--- a/src/main/java/com/dis/bot/commands/init/ShowInitCommand.java
+++ b/src/main/java/com/dis/bot/commands/init/ShowInitCommand.java
@@ -1,18 +1,23 @@
 package com.dis.bot.commands.init;
 
 import com.dis.bot.commands.SlashCommand;
+import com.dis.bot.service.CombatService;
 import com.dis.bot.service.InitiativeService;
 import discord4j.core.event.domain.interaction.ChatInputInteractionEvent;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
+import static com.dis.bot.tool.ChannelGetter.getChannel;
+
 @Component
 public class ShowInitCommand implements SlashCommand {
 
     private final InitiativeService service;
+    private final CombatService combatService;
 
-    public ShowInitCommand(InitiativeService service){
+    public ShowInitCommand(InitiativeService service, CombatService combatService){
         this.service = service;
+        this.combatService = combatService;
     }
 
     @Override
@@ -22,8 +27,9 @@ public class ShowInitCommand implements SlashCommand {
 
     @Override
     public Mono<Void> handle(ChatInputInteractionEvent event) {
+        var combat = combatService.getCurrentChannelActiveCombat(getChannel(event));
         return  event.reply()
             .withEphemeral(false)
-            .withContent(service.showInitiativeTable());
+            .withContent(service.showInitiativeTable(combat));
     }
 }

--- a/src/main/java/com/dis/bot/exception/CharacterException.java
+++ b/src/main/java/com/dis/bot/exception/CharacterException.java
@@ -1,6 +1,6 @@
 package com.dis.bot.exception;
 
-public class CharacterException extends RuntimeException{
+public class CharacterException extends CombatSheetGenericException {
     public CharacterException(String message) {
         super(message);
     }

--- a/src/main/java/com/dis/bot/exception/CombatException.java
+++ b/src/main/java/com/dis/bot/exception/CombatException.java
@@ -1,0 +1,7 @@
+package com.dis.bot.exception;
+
+public class CombatException extends CombatSheetGenericException {
+    public CombatException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/dis/bot/exception/CombatNotFoundException.java
+++ b/src/main/java/com/dis/bot/exception/CombatNotFoundException.java
@@ -1,0 +1,9 @@
+package com.dis.bot.exception;
+
+public class CombatNotFoundException extends CombatException {
+    private final static String MESSAGE = "Combat not found";
+
+    public CombatNotFoundException(String characterName){
+        super(String.format("%s %s", MESSAGE, characterName));
+    }
+}

--- a/src/main/java/com/dis/bot/exception/CombatSheetGenericException.java
+++ b/src/main/java/com/dis/bot/exception/CombatSheetGenericException.java
@@ -1,0 +1,7 @@
+package com.dis.bot.exception;
+
+public class CombatSheetGenericException extends RuntimeException {
+    public CombatSheetGenericException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/dis/bot/exception/InvalidActiveCombatFoundException.java
+++ b/src/main/java/com/dis/bot/exception/InvalidActiveCombatFoundException.java
@@ -1,0 +1,12 @@
+package com.dis.bot.exception;
+
+import com.dis.bot.service.CombatService;
+
+public class InvalidActiveCombatFoundException extends CombatException {
+    private final static String MESSAGE = "No Active Combat found for channel";
+
+    public InvalidActiveCombatFoundException(String channel){
+        super(String.format("%s %s", MESSAGE, channel));
+    }
+
+}

--- a/src/main/java/com/dis/bot/exception/InvalidActiveCombatFoundException.java
+++ b/src/main/java/com/dis/bot/exception/InvalidActiveCombatFoundException.java
@@ -2,11 +2,10 @@ package com.dis.bot.exception;
 
 import com.dis.bot.service.CombatService;
 
-public class InvalidActiveCombatFoundException extends CombatException {
-    private final static String MESSAGE = "No Active Combat found for channel";
+public class InvalidActiveCombatFoundException extends RuntimeException {
+    private final static String MESSAGE = "No Active Combat found for this channel";
 
-    public InvalidActiveCombatFoundException(String channel){
-        super(String.format("%s %s", MESSAGE, channel));
+    public static String getFormattedMessage() {
+        return MESSAGE;
     }
-
 }

--- a/src/main/java/com/dis/bot/listeners/SlashCommandListener.java
+++ b/src/main/java/com/dis/bot/listeners/SlashCommandListener.java
@@ -1,9 +1,6 @@
 package com.dis.bot.listeners;
 
 import com.dis.bot.commands.SlashCommand;
-import com.dis.bot.exception.CharacterException;
-import com.dis.bot.exception.CharacterForMemberNotFoundException;
-import com.dis.bot.exception.CharacterNotFoundException;
 import com.dis.bot.exception.CombatSheetGenericException;
 import discord4j.core.GatewayDiscordClient;
 import discord4j.core.event.domain.interaction.ChatInputInteractionEvent;

--- a/src/main/java/com/dis/bot/listeners/SlashCommandListener.java
+++ b/src/main/java/com/dis/bot/listeners/SlashCommandListener.java
@@ -4,6 +4,7 @@ import com.dis.bot.commands.SlashCommand;
 import com.dis.bot.exception.CharacterException;
 import com.dis.bot.exception.CharacterForMemberNotFoundException;
 import com.dis.bot.exception.CharacterNotFoundException;
+import com.dis.bot.exception.CombatSheetGenericException;
 import discord4j.core.GatewayDiscordClient;
 import discord4j.core.event.domain.interaction.ChatInputInteractionEvent;
 import org.springframework.stereotype.Component;
@@ -24,7 +25,6 @@ public class SlashCommandListener {
         client.on(ChatInputInteractionEvent.class, this::handle).subscribe();
     }
 
-
     public Mono<Void> handle(ChatInputInteractionEvent event) {
         //Convert our list to a flux that we can iterate through
         return Flux.fromIterable(commands)
@@ -36,7 +36,7 @@ public class SlashCommandListener {
                 .flatMap(command -> {
                     try {
                         return command.handle(event);
-                    }catch (CharacterException e){
+                    }catch (CombatSheetGenericException e){
                         return event.reply()
                                 .withEphemeral(false)
                                 .withContent(e.getLocalizedMessage());

--- a/src/main/java/com/dis/bot/pojo/character/DNDCharacter.java
+++ b/src/main/java/com/dis/bot/pojo/character/DNDCharacter.java
@@ -1,4 +1,4 @@
-package com.dis.bot.character;
+package com.dis.bot.pojo.character;
 
 
 import lombok.Getter;

--- a/src/main/java/com/dis/bot/pojo/character/DNDNextCharacter.java
+++ b/src/main/java/com/dis/bot/pojo/character/DNDNextCharacter.java
@@ -1,4 +1,4 @@
-package com.dis.bot.character;
+package com.dis.bot.pojo.character;
 
 public class DNDNextCharacter extends DNDCharacter {
     Long strengthDefense;

--- a/src/main/java/com/dis/bot/pojo/character/RPGCharacter.java
+++ b/src/main/java/com/dis/bot/pojo/character/RPGCharacter.java
@@ -1,4 +1,4 @@
-package com.dis.bot.character;
+package com.dis.bot.pojo.character;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/dis/bot/pojo/character/ThirteenthAgeRPGCharacter.java
+++ b/src/main/java/com/dis/bot/pojo/character/ThirteenthAgeRPGCharacter.java
@@ -1,4 +1,4 @@
-package com.dis.bot.character;
+package com.dis.bot.pojo.character;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/dis/bot/pojo/combat/Combat.java
+++ b/src/main/java/com/dis/bot/pojo/combat/Combat.java
@@ -18,4 +18,8 @@ public class Combat {
     String channel;
     LocalDateTime start;
     LocalDateTime end;
+
+    public void nextRound(){
+        setRound(this.getRound() + 1);
+    }
 }

--- a/src/main/java/com/dis/bot/pojo/combat/Combat.java
+++ b/src/main/java/com/dis/bot/pojo/combat/Combat.java
@@ -5,14 +5,14 @@ import lombok.Builder;
 import lombok.Data;
 
 import java.time.LocalDateTime;
-import java.util.Collection;
+import java.util.Set;
 import java.util.UUID;
 
 @Data
 @Builder
 public class Combat {
     UUID id;
-    Collection<RPGCharacter> characters;
+    Set<RPGCharacter> characters;
     int round;
     boolean active;
     String channel;
@@ -21,5 +21,8 @@ public class Combat {
 
     public void nextRound(){
         setRound(this.getRound() + 1);
+    }
+    public void addCharacter(RPGCharacter character){
+        this.getCharacters().add(character);
     }
 }

--- a/src/main/java/com/dis/bot/pojo/combat/Combat.java
+++ b/src/main/java/com/dis/bot/pojo/combat/Combat.java
@@ -1,0 +1,21 @@
+package com.dis.bot.pojo.combat;
+
+import com.dis.bot.pojo.character.RPGCharacter;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.UUID;
+
+@Data
+@Builder
+public class Combat {
+    UUID id;
+    Collection<RPGCharacter> characters;
+    int round;
+    boolean active;
+    String channel;
+    LocalDateTime start;
+    LocalDateTime end;
+}

--- a/src/main/java/com/dis/bot/repository/Characters.java
+++ b/src/main/java/com/dis/bot/repository/Characters.java
@@ -6,10 +6,10 @@ import com.dis.bot.exception.CharacterNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 @Component
 @Slf4j
@@ -74,8 +74,8 @@ public class Characters {
         return character;
     }
 
-    public List<RPGCharacter> get(String[] charactersNames){
-        var result = new ArrayList<RPGCharacter>();
+    public Set<RPGCharacter> get(String[] charactersNames){
+        var result = new HashSet<RPGCharacter>();
         for (String characterName : charactersNames) {
             var character = characters.get(characterName);
             if(character == null){

--- a/src/main/java/com/dis/bot/repository/Characters.java
+++ b/src/main/java/com/dis/bot/repository/Characters.java
@@ -1,12 +1,14 @@
 package com.dis.bot.repository;
 
-import com.dis.bot.character.RPGCharacter;
+import com.dis.bot.pojo.character.RPGCharacter;
 import com.dis.bot.exception.CharacterForMemberNotFoundException;
 import com.dis.bot.exception.CharacterNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @Component
@@ -70,6 +72,18 @@ public class Characters {
     public RPGCharacter store(RPGCharacter character){
         characters.putIfAbsent(character.getName(), character);
         return character;
+    }
+
+    public List<RPGCharacter> get(String[] charactersNames){
+        var result = new ArrayList<RPGCharacter>();
+        for (String characterName : charactersNames) {
+            var character = characters.get(characterName);
+            if(character == null){
+                throw new CharacterNotFoundException(characterName);
+            }
+            result.add(character);
+        }
+        return result;
     }
 
 }

--- a/src/main/java/com/dis/bot/repository/Combats.java
+++ b/src/main/java/com/dis/bot/repository/Combats.java
@@ -1,6 +1,7 @@
 package com.dis.bot.repository;
 
 import com.dis.bot.exception.CombatNotFoundException;
+import com.dis.bot.exception.InvalidActiveCombatFoundException;
 import com.dis.bot.pojo.combat.Combat;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -30,5 +31,12 @@ public class Combats {
                 .filter(combat -> combat.getId().equals(UUID.fromString(id)))
                 .findFirst()
                 .orElseThrow(() -> new CombatNotFoundException(id));
+    }
+
+    public Combat getCurrentCombat(String channel) {
+        return combats.stream().filter(Combat::isActive)
+                .filter(combat -> combat.getChannel().equals(channel))
+                .findFirst()
+                .orElseThrow(() -> new InvalidActiveCombatFoundException(channel));
     }
 }

--- a/src/main/java/com/dis/bot/repository/Combats.java
+++ b/src/main/java/com/dis/bot/repository/Combats.java
@@ -37,6 +37,6 @@ public class Combats {
         return combats.stream().filter(Combat::isActive)
                 .filter(combat -> combat.getChannel().equals(channel))
                 .findFirst()
-                .orElseThrow(() -> new InvalidActiveCombatFoundException(channel));
+                .orElseThrow(InvalidActiveCombatFoundException::new);
     }
 }

--- a/src/main/java/com/dis/bot/repository/Combats.java
+++ b/src/main/java/com/dis/bot/repository/Combats.java
@@ -1,0 +1,34 @@
+package com.dis.bot.repository;
+
+import com.dis.bot.exception.CombatNotFoundException;
+import com.dis.bot.pojo.combat.Combat;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Component
+@Slf4j
+public class Combats {
+
+    final List<Combat> combats;
+
+
+    public Combats() {
+        this.combats = new ArrayList<>();
+    }
+
+    public Combat create(Combat combat){
+        combats.add(combat);
+        return combat;
+    }
+
+    public Combat get(String id){
+        return combats.stream()
+                .filter(combat -> combat.getId().equals(UUID.fromString(id)))
+                .findFirst()
+                .orElseThrow(() -> new CombatNotFoundException(id));
+    }
+}

--- a/src/main/java/com/dis/bot/repository/age/AgeCharacters.java
+++ b/src/main/java/com/dis/bot/repository/age/AgeCharacters.java
@@ -1,6 +1,6 @@
 package com.dis.bot.repository.age;
 
-import com.dis.bot.character.ThirteenthAgeRPGCharacter;
+import com.dis.bot.pojo.character.ThirteenthAgeRPGCharacter;
 import com.dis.bot.exception.AgeCharacterNotFoundException;
 import com.dis.bot.repository.dnd.DndCharacters;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/dis/bot/repository/dnd/DndCharacters.java
+++ b/src/main/java/com/dis/bot/repository/dnd/DndCharacters.java
@@ -1,6 +1,6 @@
 package com.dis.bot.repository.dnd;
 
-import com.dis.bot.character.DNDCharacter;
+import com.dis.bot.pojo.character.DNDCharacter;
 import com.dis.bot.repository.Characters;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/dis/bot/service/CombatService.java
+++ b/src/main/java/com/dis/bot/service/CombatService.java
@@ -52,4 +52,8 @@ public class CombatService {
         return combat;
 
     }
+
+    public Combat getCurrentChannelActiveCombat(String channel) {
+        return combats.getCurrentCombat(channel);
+    }
 }

--- a/src/main/java/com/dis/bot/service/CombatService.java
+++ b/src/main/java/com/dis/bot/service/CombatService.java
@@ -2,6 +2,7 @@ package com.dis.bot.service;
 
 import com.dis.bot.pojo.combat.Combat;
 import com.dis.bot.repository.Characters;
+import com.dis.bot.repository.Combats;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -13,9 +14,11 @@ import java.util.UUID;
 public class CombatService {
 
     private final Characters characters;
+    private final Combats combats;
 
-    public CombatService(Characters characters){
+    public CombatService(Characters characters, Combats combats){
         this.characters = characters;
+        this.combats = combats;
     }
 
     public Combat newCombat(String[] charactersNames, String channel) {
@@ -28,8 +31,17 @@ public class CombatService {
                 .channel(channel)
                 .build();
 
+        combats.create(combat);
         log.info("Combat [{}] was created", combat.getId());
 
+        return combat;
+    }
+
+    public Combat endCombat(String id) {
+        var combat = combats.get(id);
+        combat.setEnd(LocalDateTime.now());
+        combat.setActive(false);
+        log.info("Combat [{}] was ended", combat.getId());
         return combat;
     }
 }

--- a/src/main/java/com/dis/bot/service/CombatService.java
+++ b/src/main/java/com/dis/bot/service/CombatService.java
@@ -1,0 +1,35 @@
+package com.dis.bot.service;
+
+import com.dis.bot.pojo.combat.Combat;
+import com.dis.bot.repository.Characters;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+@Slf4j
+public class CombatService {
+
+    private final Characters characters;
+
+    public CombatService(Characters characters){
+        this.characters = characters;
+    }
+
+    public Combat newCombat(String[] charactersNames, String channel) {
+        var combat = Combat.builder()
+                .start(LocalDateTime.now())
+                .active(true)
+                .id(UUID.randomUUID())
+                .round(0)
+                .characters(characters.get(charactersNames))
+                .channel(channel)
+                .build();
+
+        log.info("Combat [{}] was created", combat.getId());
+
+        return combat;
+    }
+}

--- a/src/main/java/com/dis/bot/service/CombatService.java
+++ b/src/main/java/com/dis/bot/service/CombatService.java
@@ -39,6 +39,10 @@ public class CombatService {
 
     public Combat endCombat(String id) {
         var combat = combats.get(id);
+        return endCombat(combat);
+    }
+
+    public Combat endCombat(Combat combat){
         combat.setEnd(LocalDateTime.now());
         combat.setActive(false);
         log.info("Combat [{}] was ended", combat.getId());

--- a/src/main/java/com/dis/bot/service/CombatService.java
+++ b/src/main/java/com/dis/bot/service/CombatService.java
@@ -50,6 +50,13 @@ public class CombatService {
         combat.nextRound();
         log.info("Combat [{}] has moved to next round [{}]", combat.getId(), combat.getRound());
         return combat;
+    }
+
+    public Combat nextRoundForChannel(String channel) {
+        var combat = combats.getCurrentCombat(channel);
+        combat.nextRound();
+        log.info("Combat [{}] has moved to next round [{}]", combat.getId(), combat.getRound());
+        return combat;
 
     }
 

--- a/src/main/java/com/dis/bot/service/CombatService.java
+++ b/src/main/java/com/dis/bot/service/CombatService.java
@@ -44,4 +44,12 @@ public class CombatService {
         log.info("Combat [{}] was ended", combat.getId());
         return combat;
     }
+
+    public Combat nextRound(String id) {
+        var combat = combats.get(id);
+        combat.nextRound();
+        log.info("Combat [{}] has moved to next round [{}]", combat.getId(), combat.getRound());
+        return combat;
+
+    }
 }

--- a/src/main/java/com/dis/bot/service/HealthPointsService.java
+++ b/src/main/java/com/dis/bot/service/HealthPointsService.java
@@ -1,6 +1,6 @@
 package com.dis.bot.service;
 
-import com.dis.bot.character.RPGCharacter;
+import com.dis.bot.pojo.character.RPGCharacter;
 import com.dis.bot.repository.Characters;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/dis/bot/service/InitiativeService.java
+++ b/src/main/java/com/dis/bot/service/InitiativeService.java
@@ -1,6 +1,7 @@
 package com.dis.bot.service;
 
 import com.dis.bot.pojo.character.RPGCharacter;
+import com.dis.bot.pojo.combat.Combat;
 import com.dis.bot.repository.Characters;
 import org.springframework.stereotype.Service;
 
@@ -24,11 +25,11 @@ public class InitiativeService {
         return result;
     }
 
-    public String showInitiativeTable(){
+    public String showInitiativeTable(Combat combat){
         StringBuilder sb = new StringBuilder();
-        sb.append("Initiative Table:::\n");
+        sb.append("Initiative Table ::: Combat id").append(combat.getId()).append("\n");
         sb.append("```\n");
-        this.characters.getAll().values().stream()
+        combat.getCharacters().stream()
                 .sorted(Comparator.comparingLong(RPGCharacter::getInitiative).reversed())
                 .forEach(character ->
                         sb.append(String.format("\t%s\t%d%n", padTo(16, character.getName()), character.getInitiative())));

--- a/src/main/java/com/dis/bot/service/InitiativeService.java
+++ b/src/main/java/com/dis/bot/service/InitiativeService.java
@@ -19,15 +19,16 @@ public class InitiativeService {
         this.characters = characters;
     }
 
-    public RPGCharacter setInitiative(String characterName, Long initiative) {
-        var result = this.characters.get(characterName);
-        result.setInitiative(initiative);
-        return result;
+    public RPGCharacter setInitiative(String characterName, Long initiative, Combat combat) {
+        var character = this.characters.get(characterName);
+        character.setInitiative(initiative);
+        combat.addCharacter(character);
+        return character;
     }
 
     public String showInitiativeTable(Combat combat){
         StringBuilder sb = new StringBuilder();
-        sb.append("Initiative Table ::: Combat id").append(combat.getId()).append("\n");
+        sb.append("Initiative Table ::: Combat id ::: [").append(combat.getId()).append("]\n");
         sb.append("```\n");
         combat.getCharacters().stream()
                 .sorted(Comparator.comparingLong(RPGCharacter::getInitiative).reversed())
@@ -37,20 +38,22 @@ public class InitiativeService {
         return sb.toString();
     }
 
-    public RPGCharacter setInitiativeFromMember(String memberName, Long initiative) {
-        var result = characters.getWithMemberName(memberName);
-        result.setInitiative(initiative);
-        return result;
+    public RPGCharacter setInitiativeFromMember(String memberName, Long initiative, Combat combat) {
+        var character = characters.getWithMemberName(memberName);
+        character.setInitiative(initiative);
+        combat.addCharacter(character);
+        return character;
     }
 
-    public RPGCharacter rollD20InitiativeFromMemberWithBonus(String memberName, Long bonus) {
-        var result = characters.getWithMemberName(memberName);
-        result.setInitiative(rollD20WithBonus(bonus));
-        return result;
+    public RPGCharacter rollD20InitiativeFromMemberWithBonus(String memberName, Long bonus, Combat combat) {
+        var character = characters.getWithMemberName(memberName);
+        character.setInitiative(rollD20WithBonus(bonus));
+        combat.addCharacter(character);
+        return character;
     }
 
-    public RPGCharacter rollD20InitiativeFromMember(String memberName) {
-        return rollD20InitiativeFromMemberWithBonus(memberName, 0L);
+    public RPGCharacter rollD20InitiativeFromMember(String memberName, Combat combat) {
+        return rollD20InitiativeFromMemberWithBonus(memberName, 0L, combat);
     }
 
 }

--- a/src/main/java/com/dis/bot/service/InitiativeService.java
+++ b/src/main/java/com/dis/bot/service/InitiativeService.java
@@ -1,6 +1,6 @@
 package com.dis.bot.service;
 
-import com.dis.bot.character.RPGCharacter;
+import com.dis.bot.pojo.character.RPGCharacter;
 import com.dis.bot.repository.Characters;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/dis/bot/service/age/AgeInitiativeService.java
+++ b/src/main/java/com/dis/bot/service/age/AgeInitiativeService.java
@@ -1,6 +1,7 @@
 package com.dis.bot.service.age;
 
 import com.dis.bot.pojo.character.RPGCharacter;
+import com.dis.bot.pojo.combat.Combat;
 import com.dis.bot.repository.age.AgeCharacters;
 import org.springframework.stereotype.Service;
 
@@ -17,9 +18,10 @@ public class AgeInitiativeService {
         this.characters = characters;
     }
 
-    public String showInitiativeTable(){
+    public String showInitiativeTable(Combat combat){
         StringBuilder sb = new StringBuilder();
-        sb.append("13th Age Initiative Table:::\n");
+        sb.append("13th Age Initiative Table ::: Combat id [").append(combat.getId())
+                .append("] ::: Round ").append(combat.getRound()).append(" \n");
         sb.append("```\n");
         sb.append("\tName        \tInitiative\t\tHP\tAC\tPD\tMD\n");
         this.characters.getAll().values().stream()

--- a/src/main/java/com/dis/bot/service/age/AgeInitiativeService.java
+++ b/src/main/java/com/dis/bot/service/age/AgeInitiativeService.java
@@ -1,6 +1,6 @@
 package com.dis.bot.service.age;
 
-import com.dis.bot.character.RPGCharacter;
+import com.dis.bot.pojo.character.RPGCharacter;
 import com.dis.bot.repository.age.AgeCharacters;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/dis/bot/service/age/MentalDefenseService.java
+++ b/src/main/java/com/dis/bot/service/age/MentalDefenseService.java
@@ -1,6 +1,6 @@
 package com.dis.bot.service.age;
 
-import com.dis.bot.character.RPGCharacter;
+import com.dis.bot.pojo.character.RPGCharacter;
 import com.dis.bot.repository.age.AgeCharacters;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/dis/bot/service/age/PhysicalDefenseService.java
+++ b/src/main/java/com/dis/bot/service/age/PhysicalDefenseService.java
@@ -1,6 +1,6 @@
 package com.dis.bot.service.age;
 
-import com.dis.bot.character.RPGCharacter;
+import com.dis.bot.pojo.character.RPGCharacter;
 import com.dis.bot.repository.age.AgeCharacters;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/dis/bot/service/dnd/ArmorClassService.java
+++ b/src/main/java/com/dis/bot/service/dnd/ArmorClassService.java
@@ -1,6 +1,6 @@
 package com.dis.bot.service.dnd;
 
-import com.dis.bot.character.RPGCharacter;
+import com.dis.bot.pojo.character.RPGCharacter;
 import com.dis.bot.repository.dnd.DndCharacters;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/dis/bot/tool/ChannelGetter.java
+++ b/src/main/java/com/dis/bot/tool/ChannelGetter.java
@@ -1,0 +1,9 @@
+package com.dis.bot.tool;
+
+import discord4j.core.event.domain.interaction.ChatInputInteractionEvent;
+
+public class ChannelGetter {
+    public static String getChannel(ChatInputInteractionEvent event) {
+        return event.getInteraction().getChannel().toString();
+    }
+}

--- a/src/main/java/com/dis/bot/tool/ChannelGetter.java
+++ b/src/main/java/com/dis/bot/tool/ChannelGetter.java
@@ -4,6 +4,6 @@ import discord4j.core.event.domain.interaction.ChatInputInteractionEvent;
 
 public class ChannelGetter {
     public static String getChannel(ChatInputInteractionEvent event) {
-        return event.getInteraction().getChannel().toString();
+        return event.getInteraction().getChannelId().asString();
     }
 }

--- a/src/main/resources/commands/rpg/combat-next-round.json
+++ b/src/main/resources/commands/rpg/combat-next-round.json
@@ -1,6 +1,6 @@
 {
-    "name": "end-combat",
-    "description": "End a combat instance",
+    "name": "combat-next-round",
+    "description": "Move to the next round a combat instance",
     "options": [
         {
             "name": "id",

--- a/src/main/resources/commands/rpg/end-combat.json
+++ b/src/main/resources/commands/rpg/end-combat.json
@@ -1,0 +1,12 @@
+{
+    "name": "end-combat",
+    "description": "End a new combat instance",
+    "options": [
+        {
+            "name": "id",
+            "description": "The id of a combat that is returned when a combat is started",
+            "type": 3,
+            "required": true
+        }
+    ]
+}

--- a/src/main/resources/commands/rpg/end.json
+++ b/src/main/resources/commands/rpg/end.json
@@ -1,0 +1,5 @@
+{
+    "name": "end",
+    "description": "Finish current combat instance",
+    "options": []
+}

--- a/src/main/resources/commands/rpg/next-round.json
+++ b/src/main/resources/commands/rpg/next-round.json
@@ -1,0 +1,4 @@
+{
+    "name": "next-round",
+    "description": "Move to the next round the current combat instance"
+}

--- a/src/main/resources/commands/rpg/next-round.json
+++ b/src/main/resources/commands/rpg/next-round.json
@@ -1,4 +1,5 @@
 {
     "name": "next-round",
-    "description": "Move to the next round the current combat instance"
+    "description": "Move to the next round the current combat instance",
+    "options": []
 }

--- a/src/main/resources/commands/rpg/start-combat.json
+++ b/src/main/resources/commands/rpg/start-combat.json
@@ -1,0 +1,12 @@
+{
+    "name": "start-combat",
+    "description": "Start a new combat instance",
+    "options": [
+        {
+            "name": "names",
+            "description": "Add characters to combat split by comma (,)",
+            "type": 3,
+            "required": true
+        }
+    ]
+}


### PR DESCRIPTION
Created the concept of combat.
All initiatives now need to be in a combat.
Created command to start a combat.
All Hidden Initiatives Commands also starts a new combat.
A character that rolls an initiative need an active combat to fulfil the command.
A combat instance happens in a channel.
Created command to start a command
Created command to move the round counter +1
Created command to move the round counter without passing the combat ID
Created command to end a combat
Created command to end a combat without passing the combat ID